### PR TITLE
Fix calculation of inline asm() length on VC4

### DIFF
--- a/gcc/config/vc4/vc4.md
+++ b/gcc/config/vc4/vc4.md
@@ -21,7 +21,7 @@
 
 ;;- See file "rtl.def" for documentation on define_insn, match_*, et. al.
 
-(define_attr "length" "" (const_int 2))
+(define_attr "length" "" (const_int 10))
 (define_attr "enabled" "no,yes" (const_string "yes"))
 (define_attr "predicable" "no,yes" (const_string "no"))
 


### PR DESCRIPTION
The longest VC4 instruction is 80 bits long, and that should be
the default value of the "length" attribute.